### PR TITLE
Fix Docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is a downstream of [alfg/nginx-rtmp](https://github.com/alfg/docker
 
 ### Docker
 ```
-docker run -it -p 1935:1935 -p 8080:80 sjsmart/dash-hls-stream
+docker run -it -p 1935:1935 -p 80:8080 sjsmart/dash-hls-stream
 ```
 
 ### Docker Compose


### PR DESCRIPTION
`nginx` listens on port 8080 within the container so we should direct requests to the internal port 8080.